### PR TITLE
Call AVCaptureSession.startRunning() on a background thread

### DIFF
--- a/Sources/SwiftQRCodeScanner/SwiftQRScanner.swift
+++ b/Sources/SwiftQRCodeScanner/SwiftQRScanner.swift
@@ -273,9 +273,11 @@ public class QRCodeScannerController: UIViewController,
     
     //MARK: - Setup and start capturing session
     
-    private func startScanningQRCode() {
+   private func startScanningQRCode() {
         if captureSession.isRunning { return }
-        captureSession.startRunning()
+        DispatchQueue.global(qos: .background).async {
+            self.captureSession.startRunning()
+        }
     }
     
     private func setupCaptureSession(_ devicePostion: AVCaptureDevice.Position) {


### PR DESCRIPTION
Avoided potential UI unresponsiveness by moving the AVCaptureSession.startRunning() method call to a background thread. Now the QR code scanning process runs asynchronously, preventing any impact on the main thread and improving overall app performance.